### PR TITLE
Rakefile: add patch to support last_comment

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,11 @@
 task :default => [ :specs ]
 
+unless Rake::Application.method_defined? :last_comment
+  Rake::Application.module_eval do
+    alias_method :last_comment, :last_description
+  end
+end # Rake 11 compatibility (due rspec/core/rake_task < 3.0)
+
 desc 'run specs'
 task :specs do
   $LOAD_PATH << "spec"


### PR DESCRIPTION
Borrowed a patch from warbler: https://github.com/jruby/warbler/blob/a1684e453290f84fad4606672e1a207af4299455/Rakefile#L21

Example test which fails without this:

https://travis-ci.org/github/mkristian/jbundler/jobs/673153372#L16669

